### PR TITLE
[Feature/camera] 카메라로 입력받기&미리보기 기능 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,9 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import MainPage from "./pages/MainPage";
+import ResultPage from "./pages/ResultPage";
+import ReportPage from "./pages/ReportPage";
+import NetworkmapPage from "./pages/NetworkmapPage";
 
 function App() {
   return (
@@ -8,6 +11,9 @@ function App() {
       <Router>
         <Routes>
           <Route path="/" element={<MainPage />} />
+          <Route path="/result" element={<ResultPage />} />
+          <Route path="/networkmap" element={<NetworkmapPage />} />
+          <Route path="/report" element={<ReportPage />} />
         </Routes>
       </Router>
     </>

--- a/src/components/CameraInput.js
+++ b/src/components/CameraInput.js
@@ -1,28 +1,90 @@
-import React from "react";
+import React, { useState, useRef } from "react";
+import AddAPhotoOutlinedIcon from "@mui/icons-material/AddAPhotoOutlined";
+import StyledButton from "./StyledButton";
 import styled from "styled-components";
-
-const CameraWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 300px;
-  width: 100%;
-  border: 1px solid black;
-`;
+import { useNavigate } from "react-router-dom";
 
 const CameraInput = () => {
+  // 파일 미리볼 url을 저장할 state
+  const [camInput, setCamInput] = useState();
+  const imgInput = useRef();
+  const navigate = useNavigate();
+
+  // 업로드 된 사진을 미리보기에 올리는 함수
+  const handleImgChange = e => {
+    // TODO: 로딩 스피너 적용하기
+    setCamInput(URL.createObjectURL(e.target.files[0]));
+  };
+
+  const handleImgInputBtnClick = e => {
+    e.preventDefault();
+    imgInput.current.click();
+  };
+
+  const handleImgRemove = e => {
+    setCamInput();
+  };
+
+  const handleImgSubmit = e => {
+    //
+
+    navigate("/result");
+  };
   return (
     <CameraWrapper>
+      <CameraButton onClick={handleImgInputBtnClick}>
+        <AddAPhotoOutlinedIcon color={"success"} fontSize={"large"} />
+      </CameraButton>
       <input
+        ref={imgInput} // ref를 달아서 image upload button에 연결시키기
         type="file"
-        id="camera"
-        name="camera"
-        capture="camera"
+        name="image"
         accept="image/*"
-      ></input>
+        capture="user" // 유저 쪽 카메라로 사진을 찍도록 함
+        style={{ display: "none" }}
+        onChange={handleImgChange}
+      />
+
+      <img
+        alt="upload"
+        src={camInput}
+        style={{ background: "lightgrey", width: "45%", height: "200px" }}
+      />
+      {camInput && (
+        <>
+          <StyledButton big onClick={handleImgSubmit}>
+            결과보기
+          </StyledButton>
+          <StyledButton big onClick={handleImgRemove}>
+            삭제하기
+          </StyledButton>
+        </>
+      )}
     </CameraWrapper>
   );
 };
 
 export default CameraInput;
+
+const CameraWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-around;
+  height: 400px;
+  width: 100%;
+  border: 1px solid black;
+`;
+
+const CameraButton = styled.button`
+  border: 0;
+  outline: 0;
+  background-color: white;
+  border: 1px solid lightgrey;
+  width: 30%;
+  height: 20%;
+  cursor: pointer;
+  &:hover {
+    background: skyblue;
+  }
+`;

--- a/src/components/Networkmap.js
+++ b/src/components/Networkmap.js
@@ -1,0 +1,18 @@
+import React from "react";
+import styled from "styled-components";
+
+const PageMoveWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 300px;
+  width: 100%;
+  border: 1px solid black;
+`;
+
+const Networkmap = () => {
+  return <PageMoveWrapper>Networkmap</PageMoveWrapper>;
+};
+
+export default Networkmap;

--- a/src/components/PageMove.js
+++ b/src/components/PageMove.js
@@ -1,18 +1,30 @@
 import React from "react";
 import styled from "styled-components";
+import StyledButton from "./StyledButton";
+import { useNavigate } from "react-router-dom";
 
 const PageMoveWrapper = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   height: 50px;
   width: 100%;
   border: 1px solid black;
 `;
 
 const PageMove = () => {
-  return <PageMoveWrapper>PageMove</PageMoveWrapper>;
+  const navigate = useNavigate();
+  return (
+    <PageMoveWrapper>
+      <StyledButton big onClick={() => navigate("/")}>
+        재검색
+      </StyledButton>
+      <StyledButton big onClick={() => navigate("/report")}>
+        신고하기
+      </StyledButton>
+    </PageMoveWrapper>
+  );
 };
 
 export default PageMove;

--- a/src/components/ReportBoard.js
+++ b/src/components/ReportBoard.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import Avatar from "@mui/material/Avatar";
 import AvatarGroup from "@mui/material/AvatarGroup";
-
+import StyledButton from "./StyledButton";
 const ReportBoard = () => {
   return (
     <Wrapper>
@@ -19,8 +19,8 @@ const ReportBoard = () => {
         </div>
       </ReportAccount>
       <ButtonWrapper>
-        <button>디지털성범죄 지원센터에 신고하기</button>
-        <button>트위터 계정 신고하기</button>
+        <StyledButton big>디지털성범죄 지원센터에 신고하기</StyledButton>
+        <StyledButton big>트위터 계정 신고하기</StyledButton>
       </ButtonWrapper>
     </Wrapper>
   );
@@ -49,7 +49,8 @@ const ReportAccount = styled.div`
 const ButtonWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  height: 50%;
-  width: inherit;
+  height: 30%;
+  width: 100%;
   justify-content: space-around;
+  align-items: center;
 `;

--- a/src/components/StyledButton.js
+++ b/src/components/StyledButton.js
@@ -1,0 +1,35 @@
+import React from "react";
+import styled from "styled-components";
+
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 30%;
+  border-radius: 20px;
+  background: #8575ff;
+  color: white;
+  height: ${props => props.height};
+  cursor: pointer;
+  font-size: ${props => props.fontSize};
+  ${props =>
+    props.big &&
+    `
+  font-size: 2rem;
+  padding: 10px;
+`}
+  &:hover {
+    background: purple;
+    color: white;
+  }
+`;
+
+const StyledButton = ({ children, big, ...rest }) => {
+  return (
+    <Wrapper fontSize="10px" {...rest}>
+      {children}
+    </Wrapper>
+  );
+};
+
+export default StyledButton;

--- a/src/pages/MainPage.js
+++ b/src/pages/MainPage.js
@@ -1,19 +1,15 @@
 import React from "react";
 import Header from "../components/Header";
-import PageMove from "../components/PageMove";
 import Description from "../components/Description";
-import Camera from "../components/Camera";
-import ImagePreview from "../components/ImagePreview";
+import CameraInput from "../components/CameraInput";
 import Footer from "../components/Footer";
 
 const MainPage = () => {
   return (
     <div className="main-container">
       <Header />
-      <PageMove />
       <Description />
-      <Camera />
-      <ImagePreview />
+      <CameraInput />
       <Footer />
     </div>
   );

--- a/src/pages/NetworkmapPage.js
+++ b/src/pages/NetworkmapPage.js
@@ -1,0 +1,20 @@
+import React from "react";
+import Header from "../components/Header";
+import PageMove from "../components/PageMove";
+import Description from "../components/Description";
+import Networkmap from "../components/Networkmap";
+import Footer from "../components/Footer";
+
+const NetworkmapPage = () => {
+  return (
+    <div className="main-container">
+      <Header />
+      <Description />
+      <Networkmap />
+      <PageMove />
+      <Footer />
+    </div>
+  );
+};
+
+export default NetworkmapPage;


### PR DESCRIPTION
# PR

## 내용
### 카메라로 입력받기&미리보기
- WebAPI로 사용자 기기에 있는 카메라로 사진을 찍고 업로드함
- useRef로 찍은 사진에 대한 참조를 imgInput으로 얻고 이미지를 업로드하는 버튼에 연결시킴
- 호출순서
  - CameraButton 클릭 (material ui의 camera icon 이용)
  - ref로 input 태그 클릭
  - onChange로 camInput의 state 값 변경
  - && 연산자로 결과보기와 삭제하기 버튼 조건부 렌더링함
 
## 체크리스트
- [ ] github.io로 배포해서 모바일 환경에서 카메라로 입력 받을 수 있는지 테스트하기
- [ ] 사진 업로드 될 때 미리보기에 로딩 스피너 적용하기
